### PR TITLE
fix: Brute Charactersheet did not display the ability discription

### DIFF
--- a/templates/actors/brute.html
+++ b/templates/actors/brute.html
@@ -45,7 +45,7 @@
         <input type="text" name="data.ability.name" value="{{data.ability.name}}" data-dtype="String" placeholder="{{localize "SVNSEA2E.Ability"}} {{localize "SVNSEA2E.Name"}}" />
       </div>
       <div class="virtue flexrow flex-group flex-between">
-        <textarea name="data.data.ability.name.description" rows="8" cols="80" data-dtype="String" placeholder="{{localize "SVNSEA2E.Ability"}}  {{localize "SVNSEA2E.Description"}}"></textarea>
+        <textarea name="data.data.ability.name.description" rows="8" cols="80" data-dtype="String" placeholder="{{localize "SVNSEA2E.Ability"}}  {{localize "SVNSEA2E.Description"}}">{{ data.data.ability.name.description }}</textarea>
       </div>
     </div>
   </section>


### PR DESCRIPTION
The Brute character sheet was not displaying the ability description because the respective variable was missing from the template.