### PR TITLE
Show correctly spanish translation

### DIFF
--- a/system.json
+++ b/system.json
@@ -24,6 +24,11 @@
       "lang": "fr",
       "name": "French",
       "path": "lang/fr.json"
+    },
+    {
+      "lang": "es",
+      "name": "Spanish",
+      "path": "lang/es.json"
     }
   ],
   "gridDistance": 5,


### PR DESCRIPTION
The spanish translation wasn't working because there wasn't a reference to the `lang/es.json` file. Added the reference to the `system.json` file.