### PR TITLE
change the way we load Content of compendium

### DIFF
--- a/module/migration.js
+++ b/module/migration.js
@@ -79,10 +79,9 @@ export const migrateCompendium = async function (pack) {
 
   // Begin by requesting server-side data model migration and get the migrated content
   await pack.migrate();
-  const content = await pack.getContent();
 
   // Iterate over compendium entries - applying fine-tuned migration functions
-  for (let ent of content) {
+  for (let ent of pack) {
     try {
       let updateData = null;
       if (entity === 'Item') updateData = migrateItemData(ent.data);


### PR DESCRIPTION
I'm using Foundryvtt last stable release. (Version 9 - Build 269)

With the changes done to [CompendiumCollection](https://foundryvtt.com/api/CompendiumCollection.html) we can directly use the pack in the For each function. The function getContent() is not used anymore.