### PR TITLE
Feature/v10 compatibility tweak

### DIFF
--- a/system.json
+++ b/system.json
@@ -4,8 +4,8 @@
   "description": "The 7th Sea Second Edition (Unofficial) system for FoundryVTT!",
   "version": "THIS IS GENERATED",
   "compatibility": {
-    "minimum": "10.277",
-    "verified": "10.278",
+    "minimum": "10",
+    "verified": "10.285",
     "maximum": "10"
   },
   "templateVersion": 2,


### PR DESCRIPTION
@psychoph I tweaked the compatibility block to be a bit more permissive until we encounter a need to be more specific. This, I believe, addresses your final concern for the `master` PR and ultimate release of v10 support.

I'd suggest v4.0.0 for the version, when you're ready to release.