### PR TITLE
Fixes #143 - sorcery and story items missing from templates.

### DIFF
--- a/public/system.json
+++ b/public/system.json
@@ -2,10 +2,10 @@
   "name": "svnsea2e",
   "title": "7th Sea Second Edition (Unofficial)",
   "description": "The 7th Sea Second Edition (Unofficial) system for FoundryVTT!",
-  "version": "3.3.3",
+  "version": "3.3.4",
   "compatibility": {
-    "minimum": "10",
-    "verified": "12.329"
+    "minimum": "12.329",
+    "verified": "13.341"
   },
   "templateVersion": 3,
   "authors": [
@@ -96,6 +96,12 @@
         "htmlFields": ["desciption"]
       },
       "shipbackground": {
+        "htmlFields": ["desciption"]
+      },
+      "sorcery": {
+        "htmlFields": ["desciption"]
+      },
+      "story": {
         "htmlFields": ["desciption"]
       },
       "virtue": {


### PR DESCRIPTION
In converting to system data models, all types have been converted in code however the template.json items were not correctly merged to the system.json. Sorcery and Story were missing from the items section. That resolved the issue with being able to see, create, or otherwise manage these items.

Additionally the deprecation fixes that I have been applying (including system data models) are not compatible before Foundry v12, so I have changed the minimum version to the version of v12 I am currently running, 12.329.